### PR TITLE
feat: add `merge_tags` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ All markdown files in the same folder and in subfolders automatically get all ta
 Change the default name of the meta file. (default=`.meta.yml`)
 
 `merge_tags`
-Merge all the meta files and page tags altogether (default=`false`)
+Merge the tags of all relevant meta files and pages for a page (default=`false`)

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ MkDocs plugin for managing meta tags across folders and files
 
 ## Usage
 
-Add meta files with the name`.meta.yml` (can be configured) in your docs file structure.
+Add meta files with the name `.meta.yml` (can be configured) in your docs file structure.
 
 All markdown files in the same folder and in subfolders automatically get all tags that are defined in the given meta file.
 
 ## Options
 
 `meta_filename`
-Change the default name of the meta file.
+Change the default name of the meta file. (default=`.meta.yml`)
+
+`merge_tags`
+Merge all the meta files and page tags altogether (default=`false`)

--- a/mkdocs_meta_manager_plugin/plugin.py
+++ b/mkdocs_meta_manager_plugin/plugin.py
@@ -9,6 +9,7 @@ from mkdocs.plugins import BasePlugin
 class MetaManagerPlugin(BasePlugin):
     config_scheme = (
         ('meta_filename', config_options.Type(str, default='.meta.yml')),
+        ('merge_tags', config_options.Type(bool, default=False)),
     )
 
     meta_files = {}
@@ -43,6 +44,8 @@ class MetaManagerPlugin(BasePlugin):
                 for key, value in self.meta_files[part].items():
                     if not key in page.meta:
                         page.meta[key] = value
+                    elif key == 'tags' and self.config['merge_tags']:
+                        page.meta[key].extend(value)
 
         logging.debug("%s: %s", page.file.src_path, page.meta)
         return markdown


### PR DESCRIPTION
This PR adds a new `merge_tags` option. When set to `true`, all the tags from a page and the meta files in its path are merged altogether. Default value=`false` preserves the current behavior.

Consider the following source tree:
- `docs/`: 
  - `dir/`: 
    - `.meta.yml`: `tag1`
    - `page1.md`: no tags
    - `page2.md`: `tag2`
    - `subdir/`: 
      - `.meta.yml`: `tag3`
      - `page3.md`: no tags
      - `page4.md`: `tag4`

Here are the tags before the change or with `merge_tags: false`:

- `dir/page1.md`: `tag1`
- `dir/page2.md`: `tag2` 
- `dir/subdir/page3.md`: `tag3`
- `dir/subdir/page4.md`: `tag4`

And after the change with `merge_tags: true`:

- `dir/page1.md`: `tag1`
- `dir/page2.md`: `tag1` `tag2` 
- `dir/subdir/page3.md`: `tag1` `tag3`
- `dir/subdir/page4.md`: `tag1` `tag3` `tag4`
