### PR TITLE
Main

### DIFF
--- a/mkdocs_meta_manager_plugin/plugin.py
+++ b/mkdocs_meta_manager_plugin/plugin.py
@@ -45,6 +45,7 @@ class MetaManagerPlugin(BasePlugin):
                     if not key in page.meta:
                         page.meta[key] = value
                     elif key == 'tags' and self.config['merge_tags']:
+                        page.meta[key] = page.meta[key].copy()
                         page.meta[key].extend(value)
 
         logging.debug("%s: %s", page.file.src_path, page.meta)


### PR DESCRIPTION
PR #9 introduced a bug where tags from parent dirs were duplicated when merged in child pages. This PR fixes the issue by making a copy of the tag array before extending it